### PR TITLE
[AI-AUDIT] Add evalType validation to GpuArrowEvalPythonExec

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowEvalPythonExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/execution/python/GpuArrowEvalPythonExec.scala
@@ -36,7 +36,7 @@ import org.apache.spark.api.python._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.rapids.execution.python.shims.{GpuArrowPythonRunner, PythonArgumentUtils}
+import org.apache.spark.sql.rapids.execution.python.shims.{ArrowEvalPythonExecShims, GpuArrowPythonRunner, PythonArgumentUtils}
 import org.apache.spark.sql.rapids.shims.{ArrowUtilsShim, DataTypeUtilsShim}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -355,6 +355,11 @@ case class GpuArrowEvalPythonExec(
     resultAttrs: Seq[Attribute],
     child: SparkPlan,
     evalType: Int) extends ShimUnaryExecNode with GpuPythonExecBase {
+
+  // Validate evalType matches what Spark's ArrowEvalPythonExec supports (SPARK-53243)
+  require(ArrowEvalPythonExecShims.supportedEvalTypes.contains(evalType),
+    s"Unexpected eval type $evalType for GpuArrowEvalPythonExec. " +
+      s"Supported types: ${ArrowEvalPythonExecShims.supportedEvalTypes.mkString(", ")}")
 
   // We split the input batch up into small pieces when sending to python for compatibility reasons
   override def coalesceAfter: Boolean = true

--- a/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/execution/python/shims/ArrowEvalPythonExecShims.scala
+++ b/sql-plugin/src/main/spark320/scala/org/apache/spark/sql/rapids/execution/python/shims/ArrowEvalPythonExecShims.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "320"}
+{"spark": "321"}
+{"spark": "321cdh"}
+{"spark": "322"}
+{"spark": "323"}
+{"spark": "324"}
+{"spark": "330"}
+{"spark": "330cdh"}
+{"spark": "330db"}
+{"spark": "331"}
+{"spark": "332"}
+{"spark": "332cdh"}
+{"spark": "332db"}
+{"spark": "333"}
+{"spark": "334"}
+{"spark": "340"}
+{"spark": "341"}
+{"spark": "341db"}
+{"spark": "342"}
+{"spark": "343"}
+{"spark": "344"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.execution.python.shims
+
+import org.apache.spark.api.python.PythonEvalType
+
+/**
+ * Shim for ArrowEvalPythonExec supported eval types.
+ * For Spark 3.2.x - 3.4.x, only Pandas UDF types are supported.
+ */
+object ArrowEvalPythonExecShims {
+  /**
+   * Returns the supported Python eval types for ArrowEvalPythonExec.
+   * These correspond to the types that Spark's ArrowEvalPythonExec accepts.
+   */
+  def supportedEvalTypes: Array[Int] = Array(
+    PythonEvalType.SQL_SCALAR_PANDAS_UDF,
+    PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF
+  )
+}

--- a/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/rapids/execution/python/shims/ArrowEvalPythonExecShims.scala
+++ b/sql-plugin/src/main/spark350/scala/org/apache/spark/sql/rapids/execution/python/shims/ArrowEvalPythonExecShims.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "350"}
+{"spark": "350db143"}
+{"spark": "351"}
+{"spark": "352"}
+{"spark": "353"}
+{"spark": "354"}
+{"spark": "355"}
+{"spark": "356"}
+{"spark": "357"}
+{"spark": "400"}
+{"spark": "401"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.execution.python.shims
+
+import org.apache.spark.api.python.PythonEvalType
+
+/**
+ * Shim for ArrowEvalPythonExec supported eval types.
+ * For Spark 3.5.x - 4.0.x, Arrow batched UDF type is added.
+ */
+object ArrowEvalPythonExecShims {
+  /**
+   * Returns the supported Python eval types for ArrowEvalPythonExec.
+   * These correspond to the types that Spark's ArrowEvalPythonExec accepts.
+   */
+  def supportedEvalTypes: Array[Int] = Array(
+    PythonEvalType.SQL_ARROW_BATCHED_UDF,
+    PythonEvalType.SQL_SCALAR_PANDAS_UDF,
+    PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF
+  )
+}

--- a/sql-plugin/src/main/spark411/scala/org/apache/spark/sql/rapids/execution/python/shims/ArrowEvalPythonExecShims.scala
+++ b/sql-plugin/src/main/spark411/scala/org/apache/spark/sql/rapids/execution/python/shims/ArrowEvalPythonExecShims.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*** spark-rapids-shim-json-lines
+{"spark": "411"}
+spark-rapids-shim-json-lines ***/
+package org.apache.spark.sql.rapids.execution.python.shims
+
+import org.apache.spark.api.python.PythonEvalType
+
+/**
+ * Shim for ArrowEvalPythonExec supported eval types.
+ * For Spark 4.1+, all Arrow UDF types including new scalar Arrow UDFs are supported.
+ */
+object ArrowEvalPythonExecShims {
+  /**
+   * Returns the supported Python eval types for ArrowEvalPythonExec.
+   * These correspond to the types that Spark's ArrowEvalPythonExec accepts.
+   */
+  def supportedEvalTypes: Array[Int] = Array(
+    PythonEvalType.SQL_ARROW_BATCHED_UDF,
+    PythonEvalType.SQL_SCALAR_ARROW_UDF,
+    PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF,
+    PythonEvalType.SQL_SCALAR_PANDAS_UDF,
+    PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF
+  )
+}

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuArrowEvalPythonExecSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuArrowEvalPythonExecSuite.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids
+
+import org.mockito.Mockito.{mock, when}
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.rapids.execution.python.GpuArrowEvalPythonExec
+import org.apache.spark.sql.rapids.execution.python.shims.ArrowEvalPythonExecShims
+
+/**
+ * Unit tests for GpuArrowEvalPythonExec evalType validation (SPARK-53243).
+ *
+ * This test suite verifies that:
+ * 1. ArrowEvalPythonExecShims returns valid supported eval types
+ * 2. GpuArrowEvalPythonExec rejects invalid eval types with IllegalArgumentException
+ * 3. GpuArrowEvalPythonExec accepts valid eval types (e.g., SQL_SCALAR_PANDAS_UDF)
+ *
+ * Note: PythonEvalType is private[spark], so we use numeric constants directly.
+ * These values are defined in org.apache.spark.api.python.PythonEvalType:
+ *   SQL_SCALAR_PANDAS_UDF = 200
+ *   SQL_SCALAR_PANDAS_ITER_UDF = 204
+ */
+class GpuArrowEvalPythonExecSuite extends AnyFunSuite {
+
+  // PythonEvalType constants (private[spark], so we define them here)
+  private val SQL_SCALAR_PANDAS_UDF = 200
+  private val SQL_SCALAR_PANDAS_ITER_UDF = 204
+
+  test("ArrowEvalPythonExecShims.supportedEvalTypes should not be empty") {
+    val supportedTypes = ArrowEvalPythonExecShims.supportedEvalTypes
+    assert(supportedTypes.nonEmpty,
+      "supportedEvalTypes should contain at least one eval type")
+  }
+
+  test("ArrowEvalPythonExecShims.supportedEvalTypes should contain SQL_SCALAR_PANDAS_UDF") {
+    // SQL_SCALAR_PANDAS_UDF (200) is supported in all Spark versions
+    val supportedTypes = ArrowEvalPythonExecShims.supportedEvalTypes
+    assert(supportedTypes.contains(SQL_SCALAR_PANDAS_UDF),
+      s"supportedEvalTypes should contain SQL_SCALAR_PANDAS_UDF (200), " +
+        s"but got: ${supportedTypes.mkString(", ")}")
+  }
+
+  test("GpuArrowEvalPythonExec should reject invalid evalType with IllegalArgumentException") {
+    val mockChild = mock(classOf[SparkPlan])
+    when(mockChild.output).thenReturn(Seq.empty)
+
+    // Use an invalid evalType that is not in any supported list
+    val invalidEvalType = 999
+
+    val exception = intercept[IllegalArgumentException] {
+      GpuArrowEvalPythonExec(
+        udfs = Seq.empty,
+        resultAttrs = Seq.empty,
+        child = mockChild,
+        evalType = invalidEvalType
+      )
+    }
+
+    assert(exception.getMessage.contains("Unexpected eval type"),
+      s"Exception message should mention 'Unexpected eval type', " +
+        s"but got: ${exception.getMessage}")
+    assert(exception.getMessage.contains(invalidEvalType.toString),
+      s"Exception message should contain the invalid evalType value ($invalidEvalType), " +
+        s"but got: ${exception.getMessage}")
+  }
+
+  test("GpuArrowEvalPythonExec should reject negative evalType") {
+    val mockChild = mock(classOf[SparkPlan])
+    when(mockChild.output).thenReturn(Seq.empty)
+
+    val negativeEvalType = -1
+
+    assertThrows[IllegalArgumentException] {
+      GpuArrowEvalPythonExec(
+        udfs = Seq.empty,
+        resultAttrs = Seq.empty,
+        child = mockChild,
+        evalType = negativeEvalType
+      )
+    }
+  }
+
+  test("GpuArrowEvalPythonExec should accept valid evalType SQL_SCALAR_PANDAS_UDF") {
+    val mockChild = mock(classOf[SparkPlan])
+    when(mockChild.output).thenReturn(Seq.empty)
+
+    // SQL_SCALAR_PANDAS_UDF (200) is supported in all Spark versions
+    val validEvalType = SQL_SCALAR_PANDAS_UDF
+
+    // Should not throw - this verifies the validation accepts valid types
+    val exec = GpuArrowEvalPythonExec(
+      udfs = Seq.empty,
+      resultAttrs = Seq.empty,
+      child = mockChild,
+      evalType = validEvalType
+    )
+
+    assert(exec.evalType == validEvalType,
+      s"evalType should be $validEvalType, but got ${exec.evalType}")
+  }
+
+  test("GpuArrowEvalPythonExec should accept valid evalType SQL_SCALAR_PANDAS_ITER_UDF") {
+    val mockChild = mock(classOf[SparkPlan])
+    when(mockChild.output).thenReturn(Seq.empty)
+
+    // SQL_SCALAR_PANDAS_ITER_UDF (204) is supported in all Spark versions
+    val validEvalType = SQL_SCALAR_PANDAS_ITER_UDF
+
+    // Should not throw
+    val exec = GpuArrowEvalPythonExec(
+      udfs = Seq.empty,
+      resultAttrs = Seq.empty,
+      child = mockChild,
+      evalType = validEvalType
+    )
+
+    assert(exec.evalType == validEvalType,
+      s"evalType should be $validEvalType, but got ${exec.evalType}")
+  }
+}


### PR DESCRIPTION
Closes #7

## Summary
Following SPARK-53243, add defensive validation to ensure `GpuArrowEvalPythonExec` only accepts valid Python eval types that are supported by Spark's `ArrowEvalPythonExec`.

This uses a shim-based approach to handle different eval types across Spark versions:
- **Spark 3.2-3.4**: `SQL_SCALAR_PANDAS_UDF`, `SQL_SCALAR_PANDAS_ITER_UDF`
- **Spark 3.5-4.0**: adds `SQL_ARROW_BATCHED_UDF`
- **Spark 4.1+**: adds `SQL_SCALAR_ARROW_UDF`, `SQL_SCALAR_ARROW_ITER_UDF`

## Changes
| File | Change |
|------|--------|
| `GpuArrowEvalPythonExec.scala` | Add `require()` validation using shim |
| `spark320/.../ArrowEvalPythonExecShims.scala` | New shim for Spark 3.2-3.4 |
| `spark350/.../ArrowEvalPythonExecShims.scala` | New shim for Spark 3.5-4.0 |
| `spark411/.../ArrowEvalPythonExecShims.scala` | New shim for Spark 4.1+ |
| `GpuArrowEvalPythonExecSuite.scala` | Unit tests (6 test cases) |

## Tests Added
- `supportedEvalTypes should not be empty`
- `supportedEvalTypes should contain SQL_SCALAR_PANDAS_UDF`
- `should reject invalid evalType with IllegalArgumentException`
- `should reject negative evalType`
- `should accept valid evalType SQL_SCALAR_PANDAS_UDF`
- `should accept valid evalType SQL_SCALAR_PANDAS_ITER_UDF`

## Test Plan
- [x] Unit tests pass for Spark 3.3.0 (spark320 shim)
- [x] Unit tests pass for Spark 3.5.0 (spark350 shim)
- [x] Unit tests pass for Spark 4.1.1 (spark411 shim)
- [x] Build passes for Spark 3.3.0 (Scala 2.12)
- [x] Build passes for Spark 3.5.0 (Scala 2.12)
- [x] Build passes for Spark 4.1.1 (Scala 2.13 + Java 17)